### PR TITLE
Add --speed option

### DIFF
--- a/src/lib/concrete_driver.ml
+++ b/src/lib/concrete_driver.ml
@@ -1,7 +1,7 @@
 open Syntax
 module Interpret = Kdo.Interpret.Concrete (Kdo.Interpret.Default_parameters)
 
-let run ~source_file use_graphical_window steps display_last config_file =
+let run ~source_file use_graphical_window steps display_last config_file speed =
   (* Parsing. *)
   Logs.info (fun m -> m "Parsing file %a..." Fpath.pp source_file);
   let* wat_module = Kdo.Parse.Wat.Module.from_file source_file in
@@ -26,7 +26,7 @@ let run ~source_file use_graphical_window steps display_last config_file =
 
   let link_state =
     Kdo.Link.Extern.modul
-      (Concrete_ono_module.m use_graphical_window steps display_last config_file)
+      (Concrete_ono_module.m use_graphical_window steps display_last config_file speed)
       link_state ~name:"ono"
   in
   let name = Some (Fpath.to_string source_file) in

--- a/src/lib/concrete_ono_module.ml
+++ b/src/lib/concrete_ono_module.ml
@@ -7,7 +7,8 @@ let sleep (duration : Kdo.Concrete.I32.t) : (unit, Owi.Result.err) Result.t =
   Ok ()
 
 let m (use_graphical_window : bool) (steps : int) (display_last : int)
-    (config_file : string) =
+    (config_file : string) (speed : int) =
+  ignore speed;
   let casted_steps = Int32.of_int steps in
   let casted_display_last = Int32.of_int display_last in
   let open Kdo.Concrete.Extern_func in
@@ -50,6 +51,9 @@ let m (use_graphical_window : bool) (steps : int) (display_last : int)
         Extern_func
           ( unit ^->. i32,
             fun () -> Ok (Kdo.Concrete.I32.of_int (Array.length grid)) ) );
+      ( "get_speed",
+        Extern_func (unit ^->. i32,
+            fun () -> Ok (Kdo.Concrete.I32.of_int (speed))));
     ]
   in
   let functions =

--- a/src/lib/concrete_ono_module.ml
+++ b/src/lib/concrete_ono_module.ml
@@ -8,7 +8,6 @@ let sleep (duration : Kdo.Concrete.I32.t) : (unit, Owi.Result.err) Result.t =
 
 let m (use_graphical_window : bool) (steps : int) (display_last : int)
     (config_file : string) (speed : int) =
-  ignore speed;
   let casted_steps = Int32.of_int steps in
   let casted_display_last = Int32.of_int display_last in
   let open Kdo.Concrete.Extern_func in

--- a/src/lib/concrete_ono_module.mli
+++ b/src/lib/concrete_ono_module.mli
@@ -3,4 +3,5 @@ val m :
   int ->
   int ->
   string ->
+  int ->
   Owi.Concrete_extern_func.extern_func Owi.Extern.Module.t

--- a/src/tool/cmd_concrete.ml
+++ b/src/tool/cmd_concrete.ml
@@ -16,6 +16,8 @@ let normalize_option_bool x = match x with None -> false | Some b -> b
 let normalize_option_fpath x =
   match x with None -> "" | Some p -> Fpath.to_string p
 
+let normalize_option_speed x = match x with None -> 1000 | Some ms -> ms
+
 let term =
   let open Term.Syntax in
   let+ () = setup_log
@@ -24,13 +26,15 @@ let term =
   and+ use_graphical_window = use_graphical_window
   and+ steps = steps
   and+ display_last = display_last
-  and+ config_file = config_file in
+  and+ config_file = config_file
+  and+ speed = speed in
   seed_generator seed;
   Ono.Concrete_driver.run ~source_file
     (normalize_option_bool use_graphical_window)
     (normalize_option_int steps)
     (normalize_option_int display_last)
     (normalize_option_fpath config_file)
+    (normalize_option_speed speed)
   |> function
   | Ok () -> Ok ()
   | Error e -> Error (`Msg (Kdo.R.err_to_string e))

--- a/src/tool/ono_cli.ml
+++ b/src/tool/ono_cli.ml
@@ -97,7 +97,7 @@ let source_file =
     required & pos 0 (some existing_file_conv) None (info [] ~doc ~docv:"FILE"))
 
 let speed =
-  let doc = "Time between two steps in miliseconds." in
+  let doc = "Time between two steps in milliseconds." in
   Arg.(value & opt (some int) None (info [ "speed" ] ~doc ~docv:"N"))
 
 let no_stop_at_failure =

--- a/src/tool/ono_cli.ml
+++ b/src/tool/ono_cli.ml
@@ -96,6 +96,10 @@ let source_file =
   Arg.(
     required & pos 0 (some existing_file_conv) None (info [] ~doc ~docv:"FILE"))
 
+let speed =
+  let doc = "Time between two steps in miliseconds." in
+  Arg.(value & opt (some int) None (info [ "speed" ] ~doc ~docv:"N"))
+
 let no_stop_at_failure =
   let doc = "Don't stop at the first failure, but continue to explore." in
   Arg.(value & flag (info [ "no-stop-at-failure" ] ~doc))

--- a/src/tool/ono_cli.ml
+++ b/src/tool/ono_cli.ml
@@ -97,7 +97,7 @@ let source_file =
     required & pos 0 (some existing_file_conv) None (info [] ~doc ~docv:"FILE"))
 
 let speed =
-  let doc = "Time between two steps in milliseconds." in
+  let doc = "Time elapsed between two steps in milliseconds." in
   Arg.(value & opt (some int) None (info [ "speed" ] ~doc ~docv:"N"))
 
 let no_stop_at_failure =

--- a/test/cram/concrete/display.t/display.wat
+++ b/test/cram/concrete/display.t/display.wat
@@ -8,6 +8,7 @@
   (import "ono" "get_grid_width" (func $get_grid_width (result i32)))
   (import "ono" "get_grid_height" (func $get_grid_height (result i32)))
   (import "ono" "get_grid_cell" (func $get_grid_cell (param i32) (result i32)))
+  (import "ono" "get_speed" (func $get_speed (result i32)))
 
   (global $WIDTH (mut i32) (i32.const 0))
   (global $HEIGHT (mut i32) (i32.const 0))
@@ -253,7 +254,7 @@
         (br_if $continue_i (i32.lt_s (local.get $i) (global.get $HEIGHT)))
       )
     )
-    (call $sleep (i32.const 1))
+    (call $sleep (call $get_speed))
   )
 
   (func $load_config

--- a/test/cram/concrete/manpage.t/run.t
+++ b/test/cram/concrete/manpage.t/run.t
@@ -21,7 +21,7 @@ Test the output of the man page:
              Seed for random number generation.
   
          --speed=N
-             Time between two steps in milliseconds.
+             Time elapsed between two steps in milliseconds.
   
          --steps=N
              Number of simulation steps to run.

--- a/test/cram/concrete/manpage.t/run.t
+++ b/test/cram/concrete/manpage.t/run.t
@@ -21,7 +21,7 @@ Test the output of the man page:
              Seed for random number generation.
   
          --speed=N
-             Time between two steps in miliseconds.
+             Time between two steps in milliseconds.
   
          --steps=N
              Number of simulation steps to run.

--- a/test/cram/concrete/manpage.t/run.t
+++ b/test/cram/concrete/manpage.t/run.t
@@ -20,6 +20,9 @@ Test the output of the man page:
          --seed=SEED
              Seed for random number generation.
   
+         --speed=N
+             Time between two steps in miliseconds.
+  
          --steps=N
              Number of simulation steps to run.
   


### PR DESCRIPTION
Option pour choisir le temps écoulé entre deux étapes en millisecondes.
La valeur par défaut est 1000 (une seconde).